### PR TITLE
Add yearly blog directories and home links

### DIFF
--- a/src/components/Blogs.jsx
+++ b/src/components/Blogs.jsx
@@ -13,7 +13,7 @@ export const blogIndex = [
 // Import every HTML file in the content/blogs directory tree. The eager option
 // pulls in the file contents at build time so the terminal can display them
 // without additional fetches.
-const blogFiles = import.meta.glob("../content/blogs/*/*.html", {
+const blogFiles = import.meta.glob("../content/blogs/*/*.md", {
   query: "?raw",
   import: "default",
   eager: true,

--- a/src/components/Blogs.jsx
+++ b/src/components/Blogs.jsx
@@ -1,11 +1,32 @@
+// Data structure representing the blog directory. Each year has its own
+// subdirectory which will contain that year's posts. To add a new year,
+// simply append an entry to `blogIndex` below and the home screen as well as
+// the terminal file tree will automatically include it.
+
+export const blogIndex = [
+  { year: "2025", glyph: "θ", color: "text-[#Ff4e4e]" },
+  { year: "2026", glyph: "λ", color: "text-[#ffa657]" },
+  { year: "2027", glyph: "Ω", color: "text-[#79c0ff]" },
+  { year: "2028", glyph: "Δ", color: "text-[#7ee787]" },
+];
+
 const blogsDir = {
-  type: 'dir',
-  contents: {
-    'welcome.md': {
-      type: 'file',
-      content: 'Blog posts coming soon.',
-    },
-  },
+  type: "dir",
+  contents: Object.fromEntries(
+    blogIndex.map(({ year }) => [
+      year,
+      {
+        type: "dir",
+        contents: {
+          "welcome.md": {
+            type: "file",
+            content: `Blog posts for ${year} coming soon.`,
+          },
+        },
+      },
+    ])
+  ),
 };
 
 export default blogsDir;
+

--- a/src/components/Blogs.jsx
+++ b/src/components/Blogs.jsx
@@ -10,22 +10,31 @@ export const blogIndex = [
   { year: "2028", glyph: "Δ", color: "text-[#7ee787]" },
 ];
 
+// Import every HTML file in the content/blogs directory tree. The eager option
+// pulls in the file contents at build time so the terminal can display them
+// without additional fetches.
+const blogFiles = import.meta.glob("../content/blogs/*/*.html", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+});
+
+// Build a file-tree structure consumed by the terminal. Years are sourced from
+// `blogIndex` for consistent ordering and styling on the home screen. Each
+// year's directory is populated with whatever HTML files exist on disk.
 const blogsDir = {
   type: "dir",
-  contents: Object.fromEntries(
-    blogIndex.map(({ year }) => [
-      year,
-      {
-        type: "dir",
-        contents: {
-          "welcome.md": {
-            type: "file",
-            content: `Blog posts for ${year} coming soon.`,
-          },
-        },
-      },
-    ])
-  ),
+  contents: blogIndex.reduce((acc, { year }) => {
+    const files = Object.entries(blogFiles)
+      .filter(([path]) => path.includes(`/blogs/${year}/`))
+      .reduce((fileAcc, [path, content]) => {
+        const name = path.split("/").pop();
+        fileAcc[name] = { type: "file", content };
+        return fileAcc;
+      }, {});
+    acc[year] = { type: "dir", contents: files };
+    return acc;
+  }, {}),
 };
 
 export default blogsDir;

--- a/src/components/FileViewer.jsx
+++ b/src/components/FileViewer.jsx
@@ -1,7 +1,11 @@
 import React from "react";
 
 export default function FileViewer({ filename, content, onClose, accentClass }) {
-  const html = React.useMemo(() => renderMarkdown(content, accentClass), [content, accentClass]);
+  const isMarkdown = filename.endsWith(".md");
+  const html = React.useMemo(
+    () => (isMarkdown ? renderMarkdown(content, accentClass) : content),
+    [content, accentClass, isMarkdown]
+  );
 
   React.useEffect(() => {
     const handleKey = (e) => {

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { blogIndex } from "./Blogs.jsx";
 
 export default function Home({ theme, onEnter, onCommand }) {
   const accent = {
@@ -7,13 +8,6 @@ export default function Home({ theme, onEnter, onCommand }) {
     ice: "text-[#80eaff]",
     red: "text-[#Ff4e4e]",
   }[theme];
-
-  const glyphs = [
-    { char: "Δ", cmd: "about",     color: "text-[#7ee787]" },  // mint/green
-    { char: "Ω", cmd: "favorites", color: "text-[#79c0ff]" },  // blue
-    { char: "λ", cmd: "research",  color: "text-[#ffa657]" },  // orange
-    { char: "θ", cmd: "projects",  color: "text-[#Ff4e4e]" },  // red
-  ];
 
 
   React.useEffect(() => {
@@ -50,26 +44,26 @@ export default function Home({ theme, onEnter, onCommand }) {
         We do what we must, because we can
       </p>
       <div className="flex justify-center gap-10 select-none">
-        {[
-          { char: "Δ", cmd: "about",     color: "text-[#7ee787]", year: 2028 },  // mint/green
-          { char: "Ω", cmd: "favorites", color: "text-[#79c0ff]", year: 2027 },  // blue
-          { char: "λ", cmd: "research",  color: "text-[#ffa657]", year: 2026 },  // orange
-          { char: "θ", cmd: "projects",  color: "text-[#Ff4e4e]", year: 2025 },  // red
-        ].map((g) => (
-          <button
-            key={g.char}
-            onClick={() => onCommand(g.cmd)}
-            className="group flex flex-col items-center gap-1 bg-transparent cursor-pointer focus:outline-none"
-            aria-label={`${g.cmd} (${g.year})`}
-          >
-            <span className={`text-4xl leading-none ${g.color} group-hover:opacity-90`}>
-              {g.char}
-            </span>
-            <span className="text-xs text-terminal-dim group-hover:opacity-100">
-              {g.year}
-            </span>
-          </button>
-        ))}
+        {blogIndex
+          .slice()
+          .reverse()
+          .map((g) => (
+            <button
+              key={g.year}
+              onClick={() => onCommand(`cd blogs/${g.year}`)}
+              className="group flex flex-col items-center gap-1 bg-transparent cursor-pointer focus:outline-none"
+              aria-label={`blogs ${g.year}`}
+            >
+              <span
+                className={`text-4xl leading-none ${g.color} group-hover:opacity-90`}
+              >
+                {g.glyph}
+              </span>
+              <span className="text-xs text-terminal-dim group-hover:opacity-100">
+                {g.year}
+              </span>
+            </button>
+          ))}
       </div>
 
 

--- a/src/content/blogs/2025/2025.md
+++ b/src/content/blogs/2025/2025.md
@@ -1,0 +1,4 @@
+# This is the heading
+## This is a subheading
+
+Hopfully this works

--- a/src/content/blogs/2025/first-post.html
+++ b/src/content/blogs/2025/first-post.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html><body>
+<h1>Welcome to 2025</h1>
+<p>First blog post for 2025.</p>
+</body></html>

--- a/src/content/blogs/2026/first-post.html
+++ b/src/content/blogs/2026/first-post.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html><body>
+<h1>Welcome to 2026</h1>
+<p>Early thoughts for 2026.</p>
+</body></html>

--- a/src/content/blogs/2027/first-post.html
+++ b/src/content/blogs/2027/first-post.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html><body>
+<h1>Welcome to 2027</h1>
+<p>Preview of 2027 content.</p>
+</body></html>

--- a/src/content/blogs/2028/first-post.html
+++ b/src/content/blogs/2028/first-post.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html><body>
+<h1>Welcome to 2028</h1>
+<p>Future posts will appear here.</p>
+</body></html>


### PR DESCRIPTION
## Summary
- structure blogs directory into yearly subfolders with placeholder content
- wire home screen Greek glyphs to navigate directly to each year's blog folder
- centralize blog year configuration for easy future expansion

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7029dea84832494530912f6ae0f42