### PR TITLE
feat: add blog explorer pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,9 @@
 import React from "react";
+import { Routes, Route } from "react-router";
 import Terminal from "./components/Terminal.jsx";
-import Home from "./components/Home.jsx"
+import Home from "./components/Home.jsx";
+import BlogYear from "./components/BlogYear.jsx";
+import BlogPost from "./components/BlogPost.jsx";
 
 export default function App() {
   const [theme, setTheme] = React.useState("green");
@@ -35,20 +38,25 @@ export default function App() {
           </div>
         </header>
         <div className="p-4">
-          {screen === "home" ? (
-            <Home
-              theme={theme}
-              onEnter={() => openTerminal()}
-              onCommand={(cmd) => openTerminal(cmd)}
+          <Routes>
+            <Route
+              path="/"
+              element={
+                screen === "home" ? (
+                  <Home theme={theme} onEnter={() => openTerminal()} />
+                ) : (
+                  <Terminal
+                    theme={theme}
+                    setTheme={setTheme}
+                    startWith={startCmd}
+                    onHome={() => setScreen("home")}
+                  />
+                )
+              }
             />
-          ) : (
-            <Terminal
-              theme={theme}
-              setTheme={setTheme}
-              startWith={startCmd}
-              onHome={() => setScreen("home")}
-            />
-          )}
+            <Route path="/blogs/:year" element={<BlogYear theme={theme} />} />
+            <Route path="/blogs/:year/:file" element={<BlogPost theme={theme} />} />
+          </Routes>
         </div>
       </div>
     </div>

--- a/src/components/BlogPost.jsx
+++ b/src/components/BlogPost.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { useParams, useNavigate } from "react-router";
+import blogsDir from "./Blogs.jsx";
+import FileViewer from "./FileViewer.jsx";
+
+export default function BlogPost({ theme }) {
+  const { year, file } = useParams();
+  const navigate = useNavigate();
+  const accent = {
+    green: "text-[#00ff99]",
+    amber: "text-terminal-warning",
+    ice: "text-[#80eaff]",
+    red: "text-[#Ff4e4e]",
+  }[theme];
+
+  const content = blogsDir.contents[year]?.contents?.[file]?.content;
+
+  if (!content) {
+    return (
+      <div className="text-sm leading-relaxed">
+        <div className="mb-2">
+          <button onClick={() => navigate(-1)} className={`hover:underline ${accent}`}>
+            ← back
+          </button>
+        </div>
+        <div>Post not found.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-sm leading-relaxed">
+      <div className="mb-2">
+        <button onClick={() => navigate(-1)} className={`hover:underline ${accent}`}>
+          ← back
+        </button>
+      </div>
+      <FileViewer
+        filename={file}
+        content={content}
+        accentClass={accent}
+        onClose={() => navigate(-1)}
+      />
+    </div>
+  );
+}
+

--- a/src/components/BlogYear.jsx
+++ b/src/components/BlogYear.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Link, useParams } from "react-router";
+import blogsDir, { blogIndex } from "./Blogs.jsx";
+
+export default function BlogYear({ theme }) {
+  const { year } = useParams();
+  const accent = {
+    green: "text-[#00ff99]",
+    amber: "text-terminal-warning",
+    ice: "text-[#80eaff]",
+    red: "text-[#Ff4e4e]",
+  }[theme];
+
+  const files = Object.keys(blogsDir.contents[year]?.contents || {});
+  const info = blogIndex.find((g) => g.year === year);
+
+  return (
+    <div className="text-sm leading-relaxed text-center space-y-6">
+      <div className="text-left">
+        <Link to="/" className={`hover:underline ${accent}`}>
+          ← back
+        </Link>
+      </div>
+      {info && (
+        <div className="flex flex-col items-center gap-1 select-none">
+          <span className={`text-4xl leading-none ${info.color}`}>{info.glyph}</span>
+          <span className="text-xs text-terminal-dim">{info.year}</span>
+        </div>
+      )}
+      <div className="grid justify-center gap-1">
+        {files.map((name) => (
+          <Link
+            key={name}
+            to={`/blogs/${year}/${name}`}
+            className={`hover:underline ${accent}`}
+          >
+            {name}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/Blogs.jsx
+++ b/src/components/Blogs.jsx
@@ -10,10 +10,10 @@ export const blogIndex = [
   { year: "2028", glyph: "Δ", color: "text-[#7ee787]" },
 ];
 
-// Import every HTML file in the content/blogs directory tree. The eager option
-// pulls in the file contents at build time so the terminal can display them
-// without additional fetches.
-const blogFiles = import.meta.glob("../content/blogs/*/*.md", {
+// Import every markdown or HTML file in the content/blogs directory tree. The
+// eager option pulls in the file contents at build time so the terminal (and
+// the new browser pages) can display them without additional fetches.
+const blogFiles = import.meta.glob("../content/blogs/*/*.{md,html}", {
   query: "?raw",
   import: "default",
   eager: true,

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,7 +1,8 @@
 import React from "react";
+import { Link } from "react-router";
 import { blogIndex } from "./Blogs.jsx";
 
-export default function Home({ theme, onEnter, onCommand }) {
+export default function Home({ theme, onEnter }) {
   const accent = {
     green: "text-[#00ff99]",
     amber: "text-terminal-warning",
@@ -25,15 +26,6 @@ export default function Home({ theme, onEnter, onCommand }) {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [onEnter]);
 
-  const LinkButton = ({ cmd, children }) => (
-    <button
-      onClick={() => onCommand(cmd)}
-      className={`hover:underline text-left ${accent}`}
-    >
-      {children}
-    </button>
-  );
-
   return (
     <div className="text-sm leading-relaxed text-center space-y-6">
       <div>
@@ -48,9 +40,9 @@ export default function Home({ theme, onEnter, onCommand }) {
           .slice()
           .reverse()
           .map((g) => (
-            <button
+            <Link
               key={g.year}
-              onClick={() => onCommand(`cd blogs/${g.year}`)}
+              to={`/blogs/${g.year}`}
               className="group flex flex-col items-center gap-1 bg-transparent cursor-pointer focus:outline-none"
               aria-label={`blogs ${g.year}`}
             >
@@ -62,17 +54,9 @@ export default function Home({ theme, onEnter, onCommand }) {
               <span className="text-xs text-terminal-dim group-hover:opacity-100">
                 {g.year}
               </span>
-            </button>
+            </Link>
           ))}
       </div>
-
-
-      {/* <div className="grid justify-center gap-1">
-        <LinkButton cmd="about">/about →</LinkButton>
-        <LinkButton cmd="favorites">/favorites →</LinkButton>
-        <LinkButton cmd="research">/research →</LinkButton>
-        <LinkButton cmd="projects">/projects →</LinkButton>
-      </div> */}
       <div className="pt-4">
         <button
           onClick={() => onEnter()}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router";
 import App from "./App.jsx";
 import "./index.css";
 
 createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- add client-side routes for browsing yearly blog directories
- link home page Greek icons to new blog pages
- render individual blog posts with FileViewer and back navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b73052cec0832497f83415af396c17