### PR TITLE
Add about and interests pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,8 @@ import Terminal from "./components/Terminal.jsx";
 import Home from "./components/Home.jsx";
 import BlogYear from "./components/BlogYear.jsx";
 import BlogPost from "./components/BlogPost.jsx";
+import About from "./components/About.jsx";
+import Interests from "./components/Interests.jsx";
 
 export default function App() {
   const [theme, setTheme] = React.useState("green");
@@ -56,6 +58,8 @@ export default function App() {
             />
             <Route path="/blogs/:year" element={<BlogYear theme={theme} />} />
             <Route path="/blogs/:year/:file" element={<BlogPost theme={theme} />} />
+            <Route path="/about" element={<About theme={theme} />} />
+            <Route path="/interests" element={<Interests theme={theme} />} />
           </Routes>
         </div>
       </div>

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+import aboutMd from "../content/about.md?raw";
+import MarkdownPage from "./MarkdownPage.jsx";
+
+export default function About(props) {
+  return <MarkdownPage {...props} filename="about.md" content={aboutMd} />;
+}

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -91,7 +91,7 @@ export default function Home({ theme, onEnter }) {
           onClick={() => onEnter()}
           className="px-3 py-1 rounded border border-white/10 hover:border-white/20"
         >
-          enter terminal
+          enter terminal mode
         </button>
       </div>
     </div>

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -78,6 +78,14 @@ export default function Home({ theme, onEnter }) {
             </Link>
           ))}
       </div>
+      <div className="flex justify-center gap-6 pt-2">
+        <Link to="/about" className={`hover:underline ${accent}`}>
+          About Me
+        </Link>
+        <Link to="/interests" className={`hover:underline ${accent}`}>
+          Interests
+        </Link>
+      </div>
       <div className="pt-4">
         <button
           onClick={() => onEnter()}

--- a/src/components/Interests.jsx
+++ b/src/components/Interests.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+import interestsMd from "../content/interests.md?raw";
+import MarkdownPage from "./MarkdownPage.jsx";
+
+export default function Interests(props) {
+  return (
+    <MarkdownPage {...props} filename="interests.md" content={interestsMd} />
+  );
+}

--- a/src/components/MarkdownPage.jsx
+++ b/src/components/MarkdownPage.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { useNavigate } from "react-router";
+import FileViewer from "./FileViewer.jsx";
+
+export default function MarkdownPage({ theme, filename, content }) {
+  const navigate = useNavigate();
+  const accent = {
+    green: "text-[#00ff99]",
+    amber: "text-terminal-warning",
+    ice: "text-[#80eaff]",
+    red: "text-[#Ff4e4e]",
+  }[theme];
+
+  return (
+    <div className="text-sm leading-relaxed">
+      <div className="mb-2">
+        <button
+          onClick={() => navigate(-1)}
+          className={`hover:underline ${accent}`}
+        >
+          ← back
+        </button>
+      </div>
+      <FileViewer
+        filename={filename}
+        content={content}
+        accentClass={accent}
+        onClose={() => navigate(-1)}
+      />
+    </div>
+  );
+}

--- a/src/components/Terminal.jsx
+++ b/src/components/Terminal.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import aboutMd from "../content/about.md?raw";
 import favoritesMd from "../content/favorites.md?raw";
+import interestsMd from "../content/interests.md?raw";
 import projectsDir from "./Projects.jsx";
 import blogsDir from "./Blogs.jsx";
 import FileViewer from "./FileViewer.jsx";
@@ -15,6 +16,7 @@ const fileTree = {
   contents: {
     "about.md": { type: "file", content: aboutMd },
     "favorites.md": { type: "file", content: favoritesMd },
+    "interests.md": { type: "file", content: interestsMd },
     projects: projectsDir,
     blogs: blogsDir,
   },

--- a/src/content/interests.md
+++ b/src/content/interests.md
@@ -1,0 +1,5 @@
+# Interests
+
+- [Open Source Software](https://opensource.com)
+- [Machine Learning](https://en.wikipedia.org/wiki/Machine_learning)
+- [Creative Coding](https://thecodingtrain.com/)


### PR DESCRIPTION
## Summary
- add About Me and Interests links beneath home page glyphs
- create reusable MarkdownPage and dedicated About/Interests pages
- wire up routes and terminal file tree to load new interests.md

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b84b450934832488febf2155aa2dc5